### PR TITLE
depend on buildship 2.2.1, including new auto sync property

### DIFF
--- a/eclipse/com.gluonhq.eclipse.plugin/src/main/java/com/gluonhq/eclipse/plugin/wizard/ProjectImportWizardController.java
+++ b/eclipse/com.gluonhq.eclipse.plugin/src/main/java/com/gluonhq/eclipse/plugin/wizard/ProjectImportWizardController.java
@@ -52,6 +52,7 @@ public class ProjectImportWizardController {
     private static final String SETTINGS_KEY_GRADLE_USER_HOME = "gradle_user_home"; //$NON-NLS-1$
     private static final String SETTINGS_KEY_BUILD_SCANS = "build_scans"; //$NON-NLS-1$
     private static final String SETTINGS_KEY_OFFLINE_MODE = "offline_mode"; //$NON-NLS-1$
+    private static final String SETTINGS_KEY_AUTO_SYNC = "auto_sync"; //$NON-NLS-1$
 
     private final ProjectImportConfiguration configuration;
 
@@ -77,6 +78,7 @@ public class ProjectImportWizardController {
         List<String> workingSets = ImmutableList.copyOf(CollectionsUtils.nullToEmpty(dialogSettings.getArray(SETTINGS_KEY_WORKING_SETS)));
         boolean buildScansEnabled = dialogSettings.getBoolean(SETTINGS_KEY_BUILD_SCANS);
         boolean offlineMode = dialogSettings.getBoolean(SETTINGS_KEY_OFFLINE_MODE);
+        boolean autoSync = dialogSettings.getBoolean(SETTINGS_KEY_AUTO_SYNC);
 
         this.configuration.setProjectDir(projectDir.orNull());
         this.configuration.setOverwriteWorkspaceSettings(false);
@@ -86,6 +88,7 @@ public class ProjectImportWizardController {
         this.configuration.setWorkingSets(workingSets);
         this.configuration.setBuildScansEnabled(buildScansEnabled);
         this.configuration.setOfflineMode(offlineMode);
+        this.configuration.setAutoSync(autoSync);
 
         // store the values every time they change
         saveFilePropertyWhenChanged(dialogSettings, SETTINGS_KEY_PROJECT_DIR, this.configuration.getProjectDir());
@@ -95,6 +98,7 @@ public class ProjectImportWizardController {
         saveStringArrayPropertyWhenChanged(dialogSettings, SETTINGS_KEY_WORKING_SETS, this.configuration.getWorkingSets());
         saveBooleanPropertyWhenChanged(dialogSettings, SETTINGS_KEY_BUILD_SCANS, this.configuration.getBuildScansEnabled());
         saveBooleanPropertyWhenChanged(dialogSettings, SETTINGS_KEY_OFFLINE_MODE, this.configuration.getOfflineMode());
+        saveBooleanPropertyWhenChanged(dialogSettings, SETTINGS_KEY_AUTO_SYNC, this.configuration.getAutoSync());
     }
 
     private GradleDistributionWrapper createGradleDistribution(Optional<String> gradleDistributionType, Optional<String> gradleDistributionConfiguration) {

--- a/eclipse/tooling-e47.target
+++ b/eclipse/tooling-e47.target
@@ -2,7 +2,10 @@
 <?pde version="3.8"?><target includeMode="feature" name="Buildship Eclipse Oxygen Target Platform" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.buildship.core" version="2.1.2.v20170807-1324"/>
+<unit id="org.eclipse.buildship.core" version="2.2.1.v20180125-1441"/>
+<repository location="http://download.eclipse.org/buildship/updates/e47/releases/2.x/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.fx.ide.jdt.core" version="3.0.0.201705220750"/>
 <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
 <unit id="org.eclipse.sdk.ide" version="4.7.0.I20170612-0950"/>


### PR DESCRIPTION
Fixes #6 by bumping buildship dependency to 2.2.1. A new property was added to the gradle import wizard to enable automatic project synchronization when a build script changes.