### PR TITLE
Update ide templates to v2.9.0

### DIFF
--- a/eclipse/com.gluonhq.eclipse.plugin/build.gradle
+++ b/eclipse/com.gluonhq.eclipse.plugin/build.gradle
@@ -13,5 +13,5 @@ repositories {
 dependencies {
     compile withEclipseBundle("org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}")
     compile withEclipseBundle("org.eclipse.buildship.core")
-    bundled 'com.gluonhq:ide-plugin-templates:2.8.0'
+    bundled 'com.gluonhq:ide-plugin-templates:2.9.0'
 }

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.gluonhq:ide-plugin-templates:2.8.0'
+    compile 'com.gluonhq:ide-plugin-templates:2.9.0'
 }
 
 

--- a/netbeans/.gitignore
+++ b/netbeans/.gitignore
@@ -9,3 +9,6 @@ build/
 .nb-gradle/
 .nb-gradle-properties
 sandbox/
+
+# Files
+keystore

--- a/netbeans/build.gradle
+++ b/netbeans/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
     providedCompile 'com.github.kelemen:netbeans-gradle-plugin:1.4.2'
 
-    compile 'com.gluonhq:ide-plugin-templates:2.8.0'
+    compile 'com.gluonhq:ide-plugin-templates:2.9.0'
     compile 'org.apache.logging.log4j:log4j-1.2-api:2.5'
 }
 


### PR DESCRIPTION
This PR updates IDE templates to 2.9.0 to use the new Gluon Mobile 5.0.0 API