### PR TITLE
Use built-in ProjectImport providers

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 
 intellij {
-    version = 'IC-2019.2'
+    version = 'IC-2019.3'
     // localPath = 'path-to-local-installation'
     // downloadSources = true
     plugins = [ 'IntelliLang', 'gradle', 'maven', 'java' ]

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -19,7 +19,7 @@
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="192"/>
+    <idea-version since-build="193"/>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
This PR updates the GluonTemplateModuleBuilder to import both Maven and Gradle projects without explicitly creating an instance of their ImportProviders and rather depends on IJ created providers to do the import.

PR also updates the minimum supported version to 2019.3