### PR TITLE
JavaFX plugin is required for version 2020.2 and later

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -27,7 +27,7 @@ intellij {
     version = 'IC-2019.3'
     // localPath = 'path-to-local-installation'
     // downloadSources = true
-    plugins = [ 'IntelliLang', 'gradle', 'maven', 'java' ]
+    plugins = [ 'IntelliLang', 'gradle', 'maven', 'java', 'javaFX' ]
     pluginName 'Gluon Plugin'
     updateSinceUntilBuild false
     sandboxDirectory = "${rootProject.projectDir}/idea-sandbox"
@@ -36,5 +36,5 @@ intellij {
 publishPlugin {
     username intellijPublishUsername
     password intellijPublishPassword
-    token = intellijPublishToken
+    token intellijPublishToken
 }

--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -1,5 +1,6 @@
-version=2.8.1
+version=2.8.2-SNAPSHOT
 javaVersion=1.8
 
 intellijPublishUsername=
 intellijPublishPassword=
+intellijPublishToken=

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.gluonhq.plugin.intellij</id>
     <name>Gluon</name>
-    <version>2.8.1</version>
+    <version>2.8.2</version>
     <vendor email="support@gluonhq.com" url="http://gluonhq.com">Gluon</vendor>
 
     <description><![CDATA[
@@ -9,7 +9,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-      <b>2.8.1</b>
+      <b>2.8.2</b>
       <ul>
       <li>Add Gluon Client support</li>
       <li>Update templates to use Gluon Mobile 6</li>
@@ -19,13 +19,14 @@
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="193"/>
+    <idea-version since-build="202"/>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>com.intellij.modules.java</depends>
+    <depends>com.intellij.javafx</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectTemplatesFactory implementation="com.gluonhq.plugin.intellij.module.GluonProjectTemplatesFactory"/>


### PR DESCRIPTION
JavaFX functionality was [recently moved out](https://plugins.jetbrains.com/plugin/14250-javafx-runtime-for-plugins) to a [new plugin](https://plugins.jetbrains.com/plugin/14250-javafx-runtime-for-plugins) for 2020.2 and later.